### PR TITLE
this request fixes #9

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,6 +38,9 @@
       var content = document.getElementById('content').value;
       var separator = document.getElementById('separator').value;
       var padding = document.getElementById('iosCompatibilityCheck').checked ? ' '.repeat(2575) :  '\u200B'.repeat(4000);
+
+      content = content.replace("https://","");
+      content = content.replace("http://","");
       var message = warning + separator + padding + content;
 
       document.getElementById('message').value = message;


### PR DESCRIPTION
For whatsapp to stop showing rich link preview, one way is we can remove https:// and http:// . I added the same 